### PR TITLE
Add card description popup

### DIFF
--- a/dist/game.js
+++ b/dist/game.js
@@ -43,6 +43,13 @@ let playerCards = [];
 let evolvedCells = new Set();
 let barrierCells = new Map();
 let cardsContainer;
+let popupContainer;
+const CARD_DESCRIPTIONS = {
+    [CardType.Disaster]: 'ランダムなセルを消滅させます。',
+    [CardType.Evolution]: 'いくつかのセルが進化し移動できるようになります。',
+    [CardType.Split]: 'セルを中心に周囲へ増殖させます。',
+    [CardType.Barrier]: '一時的に周囲を守るバリアを張ります。'
+};
 function preload() { }
 function create() {
     graphics = this.add.graphics();
@@ -75,6 +82,10 @@ function create() {
     infoContainer = document.getElementById('infoContainer');
     if (infoContainer) {
         infoContainer.textContent = '';
+    }
+    popupContainer = document.getElementById('popup');
+    if (popupContainer) {
+        popupContainer.style.display = 'none';
     }
     if (startButton) {
         startButton.addEventListener('click', () => {
@@ -385,9 +396,34 @@ function displayCards() {
         btn.textContent = card.type;
         btn.style.marginRight = '4px';
         btn.addEventListener('click', () => {
-            useCard(index);
+            showCardPopup(index);
         });
         cardsContainer.appendChild(btn);
+    });
+}
+function showCardPopup(index) {
+    var _a, _b;
+    if (!popupContainer)
+        return;
+    const card = playerCards[index];
+    if (!card)
+        return;
+    popupContainer.innerHTML = `<div style="position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);background:#333;padding:20px;border-radius:5px;">
+        <p>${CARD_DESCRIPTIONS[card.type]}</p>
+        <button id="popupUse">Use</button>
+        <button id="popupClose">Close</button>
+    </div>`;
+    popupContainer.style.display = 'block';
+    const close = () => {
+        if (popupContainer) {
+            popupContainer.style.display = 'none';
+            popupContainer.innerHTML = '';
+        }
+    };
+    (_a = document.getElementById('popupClose')) === null || _a === void 0 ? void 0 : _a.addEventListener('click', close);
+    (_b = document.getElementById('popupUse')) === null || _b === void 0 ? void 0 : _b.addEventListener('click', () => {
+        useCard(index);
+        close();
     });
 }
 function useCard(index) {

--- a/game.ts
+++ b/game.ts
@@ -48,6 +48,14 @@ let playerCards: Card[] = [];
 let evolvedCells = new Set<string>();
 let barrierCells = new Map<string, number>();
 let cardsContainer: HTMLElement | null;
+let popupContainer: HTMLElement | null;
+
+const CARD_DESCRIPTIONS: Record<CardType, string> = {
+    [CardType.Disaster]: 'ランダムなセルを消滅させます。',
+    [CardType.Evolution]: 'いくつかのセルが進化し移動できるようになります。',
+    [CardType.Split]: 'セルを中心に周囲へ増殖させます。',
+    [CardType.Barrier]: '一時的に周囲を守るバリアを張ります。'
+};
 
 function preload(this: any) { }
 
@@ -90,6 +98,10 @@ function create(this: any) {
     infoContainer = document.getElementById('infoContainer');
     if (infoContainer) {
         infoContainer.textContent = '';
+    }
+    popupContainer = document.getElementById('popup');
+    if (popupContainer) {
+        popupContainer.style.display = 'none';
     }
 
     if (startButton) {
@@ -426,9 +438,32 @@ function displayCards() {
         btn.textContent = card.type;
         btn.style.marginRight = '4px';
         btn.addEventListener('click', () => {
-            useCard(index);
+            showCardPopup(index);
         });
         cardsContainer!.appendChild(btn);
+    });
+}
+
+function showCardPopup(index: number) {
+    if (!popupContainer) return;
+    const card = playerCards[index];
+    if (!card) return;
+    popupContainer.innerHTML = `<div style="position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);background:#333;padding:20px;border-radius:5px;">
+        <p>${CARD_DESCRIPTIONS[card.type]}</p>
+        <button id="popupUse">Use</button>
+        <button id="popupClose">Close</button>
+    </div>`;
+    popupContainer.style.display = 'block';
+    const close = () => {
+        if (popupContainer) {
+            popupContainer.style.display = 'none';
+            popupContainer.innerHTML = '';
+        }
+    };
+    document.getElementById('popupClose')?.addEventListener('click', close);
+    document.getElementById('popupUse')?.addEventListener('click', () => {
+        useCard(index);
+        close();
     });
 }
 

--- a/index.html
+++ b/index.html
@@ -28,6 +28,7 @@
     <div id="cardsContainer" style="position: absolute; top: 50px; left: 10px; z-index: 100;"></div>
     <div id="infoContainer" style="position: absolute; top: 10px; right: 10px; z-index: 100; color: white;"></div>
     <div id="game-container"></div>
+    <div id="popup" style="display:none; position: absolute; top:0; left:0; width:100%; height:100%; background: rgba(0,0,0,0.5); z-index:200; color:white; text-align:center;"></div>
     <script src="dist/game.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- show an overlay popup for event card details
- hook popup into card buttons
- include card description data

## Testing
- `npm run build`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685f65a1432c832398bc5311c9007d8b